### PR TITLE
Update shop.component.jsx

### DIFF
--- a/src/pages/shop/shop.component.jsx
+++ b/src/pages/shop/shop.component.jsx
@@ -6,11 +6,11 @@ import CollectionsOverviewContainer from '../../components/collections-overview/
 import CollectionPageContainer from '../collection/collection.container';
 
 const ShopPage = ({ fetchCollectionsStart, match }) => {
-  const dispatch = useDispatch();
-  const fetchCollectionsStartHandler = dispatch(fetchCollectionsStart());
-  useEffect(() => {
-    fetchCollectionsStartHandler();
-  }, [fetchCollectionsStartHandler]);
+   const dispatch = useDispatch();
+  
+   useEffect(() => {
+      dispatch(fetchCollectionsStart());
+    }, [dispatch]);
 
   return (
     <div className='shop-page'>


### PR DESCRIPTION
I changed it because the earlier code which was:

const dispatch= useDispatch();
const fetchCollectionsStartHandler = dispatch(fetchCollectionsStart());

useEffect(()=>{
fetchCollectionsStartHandler();
}, [fetchCollectionsStartHandler]);

It would throw an error as fetchCollectionsStartHandler is not a function but is being initialized as a function. We are just storing the value of dispatch in fetchCollectionsStartHandler. So, it's much better to use dispatch directly in useEffect as it will only re-render if dispatch updates in the future. NOTE:  You have to pass dispatch as a dependency in the second argument of useEffect.